### PR TITLE
remove references to nested data

### DIFF
--- a/macros/stitch/stitch_adwords_ad_groups.sql
+++ b/macros/stitch/stitch_adwords_ad_groups.sql
@@ -24,10 +24,8 @@ ad_groups_renamed as (
         basecampaignid as base_campaign_id,
         campaignid as campaign_id,
         campaignname as campaign_name,
-        settings,
         status,
-        "_SDC_CUSTOMER_ID" as account_id,
-        labels
+        "_SDC_CUSTOMER_ID" as account_id
 
     from ad_groups_source
 

--- a/macros/stitch/stitch_adwords_ads.sql
+++ b/macros/stitch/stitch_adwords_ads.sql
@@ -20,7 +20,6 @@ ads_renamed as (
         adgroupid as ad_id,
         baseadgroupid as base_ad_group_id,
         basecampaignid as base_campaign_id,
-        policysummary as policy_summary,
         status,
         "_SDC_CUSTOMER_ID" as account_id
 

--- a/macros/stitch/stitch_adwords_campaigns.sql
+++ b/macros/stitch/stitch_adwords_campaigns.sql
@@ -26,10 +26,8 @@ campaigns_renamed as (
         startdate as start_date,
         enddate as end_date,
         servingstatus as serving_status,
-        settings,
         status,
-        "_SDC_CUSTOMER_ID" as account_id,
-        labels
+        "_SDC_CUSTOMER_ID" as account_id
 
     from campaigns_source
 


### PR DESCRIPTION
For now, the dbt adwords package doesn't support Stitch source data when the target database doesn't support nested data.

This PR removes the references to those fields so the dbt models can still be created. If/when those fields are needed, there should be foreign keys in the source data that can be used to pull them in with downstream dbt models.